### PR TITLE
marshal: do not escape newlines in chardata

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -202,7 +202,7 @@ func (enc *Encoder) EncodeToken(t Token) error {
 			return err
 		}
 	case CharData:
-		EscapeText(p, t)
+		escapeText(p, t, false)
 	case Comment:
 		if bytes.Contains(t, endComment) {
 			return fmt.Errorf("xml: EncodeToken of Comment containing --> marker")

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1221,6 +1221,12 @@ var encodeTokenTests = []struct {
 	},
 	want: "foo",
 }, {
+	about: "char data with escaped chars",
+	toks: []Token{
+		CharData(" \t\n"),
+	},
+	want: " &#x9;\n",
+}, {
 	about: "comment",
 	toks: []Token{
 		Comment("foo"),

--- a/xml.go
+++ b/xml.go
@@ -1858,6 +1858,13 @@ var (
 // EscapeText writes to w the properly escaped XML equivalent
 // of the plain text data s.
 func EscapeText(w io.Writer, s []byte) error {
+	return escapeText(w, s, true)
+}
+
+// escapeText writes to w the properly escaped XML equivalent
+// of the plain text data s. If escapeNewline is true, newline
+// characters will be escaped.
+func escapeText(w io.Writer, s []byte, escapeNewline bool) error {
 	var esc []byte
 	last := 0
 	for i := 0; i < len(s); {
@@ -1877,6 +1884,9 @@ func EscapeText(w io.Writer, s []byte) error {
 		case '\t':
 			esc = esc_tab
 		case '\n':
+			if !escapeNewline {
+				continue
+			}
 			esc = esc_nl
 		case '\r':
 			esc = esc_cr


### PR DESCRIPTION
Fixes https://code.google.com/p/go/issues/detail?id=9204
